### PR TITLE
Add toml support for config read

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"autoAPI/config/fields/docker"
 	"encoding/json"
 	"errors"
+	"github.com/pelletier/go-toml"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
 	"io/ioutil"
@@ -15,9 +16,9 @@ import (
 )
 
 type Config struct {
-	Docker   *docker.Docker     `yaml:"docker" json:"docker"`
-	CICD     *cicd.CICD         `yaml:"cicd" json:"cicd"`
-	Database *database.Database `yaml:"database" json:"database"`
+	Docker   *docker.Docker     `yaml:"docker" json:"docker" toml:"docker"`
+	CICD     *cicd.CICD         `yaml:"cicd" json:"cicd" toml:"cicd"`
+	Database *database.Database `yaml:"database" json:"database" toml:"database"`
 }
 
 func FromCommandLine(c *cli.Context) (*Config, error) {
@@ -88,6 +89,15 @@ func FromJson(data []byte) (*Config, error) {
 	return &result, err
 }
 
+// FromToml scan to config from toml format content
+func FromToml(data []byte) (*Config, error) {
+	var result Config
+	err := toml.Unmarshal(data, &result)
+	return &result, err
+}
+
+// FromConfigFile scan to config from file content
+// only support json/yml/yaml and toml now
 func FromConfigFile(path string) (*Config, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -102,8 +112,10 @@ func FromConfigFile(path string) (*Config, error) {
 		return FromJson(content)
 	case ".yaml", ".yml":
 		return FromYaml(content)
+	case ".toml":
+		return FromToml(content)
 	default:
-		return nil, errors.New("only support json or yaml now")
+		return nil, errors.New("only support json/yml/yaml and toml now")
 	}
 }
 

--- a/config/fields/cicd/cicd.go
+++ b/config/fields/cicd/cicd.go
@@ -3,8 +3,8 @@ package cicd
 import "github.com/urfave/cli/v2"
 
 type CICD struct {
-	GithubAction *bool `yaml:"GitHubAction" json:"GitHubAction"`
-	K8s          *bool `yaml:"k8s" json:"k8s"`
+	GithubAction *bool `yaml:"GitHubAction" json:"GitHubAction" toml:"GitHubAction"`
+	K8s          *bool `yaml:"k8s" json:"k8s" toml:"k8s"`
 }
 
 func (cicd *CICD) MergeWithDefault() error {

--- a/config/fields/database/complex/complex.go
+++ b/config/fields/database/complex/complex.go
@@ -7,21 +7,21 @@ import (
 )
 
 type QueryResult struct {
-	Array  bool          `yaml:"array" json:"array"`
-	Fields []field.Field `yaml:"fields" json:"fields"`
+	Array  bool          `yaml:"array" json:"array" toml:"array"`
+	Fields []field.Field `yaml:"fields" json:"fields" toml:"fields"`
 }
 
 type QueryParam struct {
-	OnThis *withCase.WithCase `yaml:"onThis,omitempty" json:"onThis,omitempty"`
-	Name   *withCase.WithCase `yaml:"name,omitempty" json:"name,omitempty"`
-	Type   string             `yaml:"type" json:"type"`
+	OnThis *withCase.WithCase `yaml:"onThis,omitempty" json:"onThis,omitempty" toml:"onThis,omitempty"`
+	Name   *withCase.WithCase `yaml:"name,omitempty" json:"name,omitempty" toml:"name,omitempty"`
+	Type   string             `yaml:"type" json:"type" toml:"type"`
 }
 
 type Complex struct {
-	Name   withCase.WithCase `yaml:"name" json:"name"`
-	SQL    string            `yaml:"sql" json:"sql"`
-	Params []QueryParam      `yaml:"params" json:"params"`
-	Result QueryResult       `yaml:"result" json:"result"`
+	Name   withCase.WithCase `yaml:"name" json:"name" toml:"name"`
+	SQL    string            `yaml:"sql" json:"sql" toml:"sql"`
+	Params []QueryParam      `yaml:"params" json:"params" toml:"params"`
+	Result QueryResult       `yaml:"result" json:"result" toml:"result"`
 }
 
 func (complex *Complex) Validate() error {

--- a/config/fields/database/database.go
+++ b/config/fields/database/database.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Database struct {
-	DBEngine *string      `yaml:"dbengine" json:"dbengine"`
-	Url      *string      `yaml:"url" json:"url"`
-	Table    *table.Table `yaml:",inline" json:",inline"`
+	DBEngine *string      `yaml:"dbengine" json:"dbengine" toml:"dbengine"`
+	Url      *string      `yaml:"url" json:"url" toml:"url"`
+	Table    *table.Table `yaml:",inline" json:",inline" toml:",inline"`
 }
 
 var Default = Database{}

--- a/config/fields/database/field/field.go
+++ b/config/fields/database/field/field.go
@@ -3,6 +3,6 @@ package field
 import "autoAPI/utility/withCase"
 
 type Field struct {
-	Name withCase.WithCase `yaml:"name" json:"name"`
-	Type string            `yaml:"type" json:"type"`
+	Name withCase.WithCase `yaml:"name" json:"name" toml:"name"`
+	Type string            `yaml:"type" json:"type" toml:"type"`
 }

--- a/config/fields/database/table/table.go
+++ b/config/fields/database/table/table.go
@@ -11,9 +11,9 @@ import (
 )
 
 type Table struct {
-	Name    *withCase.WithCase `yaml:"tablename" json:"tablename"`
-	Fields  []field.Field      `yaml:"fields" json:"fields"`
-	Complex []complex.Complex  `yaml:"complex" json:"complex"`
+	Name    *withCase.WithCase `yaml:"tablename" json:"tablename" toml:"tablename"`
+	Fields  []field.Field      `yaml:"fields" json:"fields" toml:"fields"`
+	Complex []complex.Complex  `yaml:"complex" json:"complex" toml:"complex"`
 }
 
 func (table *Table) MergeWith(other *Table) {

--- a/config/fields/docker/docker.go
+++ b/config/fields/docker/docker.go
@@ -6,8 +6,8 @@ import (
 )
 
 type Docker struct {
-	Username *string `yaml:"username" json:"username"`
-	Tag      *string `yaml:"tag" json:"tag"`
+	Username *string `yaml:"username" json:"username" toml:"username"`
+	Tag      *string `yaml:"tag" json:"tag" toml:"tag"`
 }
 
 func (docker *Docker) MergeWith(other *Docker) {

--- a/example/student.toml
+++ b/example/student.toml
@@ -1,0 +1,57 @@
+[docker]
+username = 'zhoudian64'
+tag = '0.0.1'
+
+[cicd]
+GitHubAction = true
+k8s = true
+
+[database]
+dbengine = 'pgsql'
+url = 'postgresql://localhost:5432/postgres?sslmode=disable'
+
+[database.table]
+tablename = 'student'
+
+[[database.table.fields]]
+name = 'name'
+type = 'varchar(24)'
+
+[[database.table.fields]]
+name = 'birthday'
+type = 'date'
+
+[[database.table.fields]]
+name = 'school_id'
+type = 'int'
+
+[[database.table.complex]]
+name = 'schools'
+sql = 'SELECT school.id, name, place FROM school, school_student, school_date WHERE school_student.student_id = $1 AND school_date.start_date >= $2 AND school_date.end_date <= $3 AND school_student.school_id = school.id'
+
+[[database.table.complex.params]]
+onThis = 'id'
+type = 'int'
+
+[[database.table.complex.params]]
+name = 'start_date'
+type = 'varchar(24)'
+
+[[database.table.complex.params]]
+name = 'end_date'
+type = 'varchar(24)'
+
+[database.table.complex.result]
+array = true
+
+[[database.table.complex.result.fields]]
+name = 'id'
+type = 'bigserial'
+
+[[database.table.complex.result.fields]]
+name = 'name'
+type = 'varchar(24)'
+
+[[database.table.complex.result.fields]]
+name = 'place'
+type = 'varchar(128)'

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/iancoleman/strcase v0.1.0
 	github.com/lib/pq v1.8.0
+	github.com/pelletier/go-toml v1.8.0
 	github.com/pingcap/parser v0.0.0-20200623164729-3a18f1e5dceb
 	github.com/pingcap/tidb v1.1.0-beta.0.20200630082100-328b6d0a955c
 	github.com/sirupsen/logrus v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.3.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
+github.com/pelletier/go-toml v1.8.0 h1:Keo9qb7iRJs2voHvunFtuuYFsbWeOBh8/P9v/kVMFtw=
+github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
 github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/phf/go-queue v0.0.0-20170504031614-9abe38d0371d/go.mod h1:lXfE4PvvTW5xOjO6Mba8zDPyw8M93B6AQ7frTGnMlA8=
 github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200407064406-b2b8ad403d01/go.mod h1:77fCh8d3oKzC5ceOJWeZXAS/mLzVgdZ7rKniwmOyFuo=

--- a/utility/withCase/withCase.go
+++ b/utility/withCase/withCase.go
@@ -3,6 +3,7 @@ package withCase
 import (
 	"encoding/json"
 	"github.com/iancoleman/strcase"
+	"github.com/pelletier/go-toml"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,6 +39,7 @@ func (s *WithCase) UnmarshalYAML(node *yaml.Node) error {
 	err := node.Decode(&s.string)
 	return err
 }
+
 func (s *WithCase) UnmarshalJSON(b []byte) error {
 	var temp string
 	err := json.Unmarshal(b, &temp)
@@ -47,6 +49,17 @@ func (s *WithCase) UnmarshalJSON(b []byte) error {
 	s.string = temp
 	return nil
 }
+
 func (s *WithCase) MarshalJson() ([]byte, error) {
 	return json.Marshal(s.string)
+}
+
+// MarshalTOML marshal `WithCase` to toml format value
+func (s *WithCase) MarshalTOML() ([]byte, error) {
+	return toml.Marshal(s.string)
+}
+
+// UnmarshalTOML unmarshal the value in toml format to `WithCase`
+func (s *WithCase) UnmarshalTOML(b []byte) error {
+	return toml.Unmarshal(b, s.string)
 }


### PR DESCRIPTION
<!--
下面的内容可以使用中文或者英文填写。
-->

<!--
You can fill the following things by using English or Chinese.
-->

<!--
注意：请不要提交包含 Java 代码或其模版代码的 pr，我们永远不会考虑支持Java。
-->

<!--
Warning: Never open an pr which contains Java code or template of Java code, we'll never consider support Java.
-->


### What problem does this PR solve?

Issue Number: close #36 

Problem Summary: 支持 TOML 配置，支持读取 .toml 文件

### What is changed and how it works?
使用 github.com/pelletier/go-toml 来支持 toml，允许读取 toml 内容 unmarshal 到 Config

What's Changed:

- config/config.go
- config/fields/cicd/cicd.go
- config/fields/database/complex/complex.go
- config/fields/database/database.go
- config/fields/database/field/field.go
- config/fields/database/table/table.go
- config/fields/docker/docker.go
- example/student.toml
- go.mod
- go.sum
- utility/withCase/withCase.go